### PR TITLE
Ticket 8687 add stale check to litron

### DIFF
--- a/litronSup/Makefile
+++ b/litronSup/Makefile
@@ -4,6 +4,7 @@ include $(TOP)/configure/CONFIG
 
 # Install .dbd and .db files
 DB += litron.db
+DB += litron_logic.db
 
 #=======================================
 include $(TOP)/configure/RULES

--- a/litronSup/litron_logic.db
+++ b/litronSup/litron_logic.db
@@ -21,11 +21,17 @@ record(compress, "$(P)STALE_CHECK:BUFFER:MIN") {
     field(NSAM, "1")
 }
 
-record(calc, "$(P)STALE"){
+record(calc, "$(P)STALE_CALC"){
     field(DESC, "Check wavelength is updating")
     field(CALC, "a=b")
     field(INPA, "$(P)STALE_CHECK:BUFFER:MAX CP MS")
     field(INPB, "$(P)STALE_CHECK:BUFFER:MIN CP MS")
-    field(HIGH, "1")
-    field(HSV, "2")
+}
+
+record(bi, "$(P)STALE"){
+    field(DESC, "Wavelength Stale")
+    field(ZNAM, "Good")
+    field(ONAM, "Stale")
+    field(INP, "$(P)STALE_CALC CP MS")
+    field(OSV, "2")
 }

--- a/litronSup/litron_logic.db
+++ b/litronSup/litron_logic.db
@@ -21,7 +21,7 @@ record(compress, "$(P)STALE_CHECK:BUFFER:MIN") {
     field(NSAM, "1")
 }
 
-record(calc, "$(P)STALE_CALC"){
+record(calc, "$(P)_STALE_CALC"){
     field(DESC, "Check wavelength is updating")
     field(CALC, "a=b")
     field(INPA, "$(P)STALE_CHECK:BUFFER:MAX CP MS")
@@ -32,6 +32,6 @@ record(bi, "$(P)STALE"){
     field(DESC, "Wavelength Stale")
     field(ZNAM, "Good")
     field(ONAM, "Stale")
-    field(INP, "$(P)STALE_CALC CP MS")
+    field(INP, "$(P)_STALE_CALC CP MS")
     field(OSV, "2")
 }

--- a/litronSup/litron_logic.db
+++ b/litronSup/litron_logic.db
@@ -1,0 +1,31 @@
+record(compress, "$(P)STALE_CHECK:BUFFER") {
+    field(DESC, "Buffer of previous wavelength values.")
+    field(ALG, "4")
+    field(INP, "$(P)WL CP MS")
+    field(NSAM, "$(BUFFER_SIZE)")
+    field(SCAN, "1 second")
+}
+
+record(compress, "$(P)STALE_CHECK:BUFFER:MAX") {
+    field(DESC, "Max recent wavelength")
+    field(ALG, "1")
+    field(INP, "$(P)STALE_CHECK:BUFFER CP MS")
+    field(NSAM, "1")
+}
+
+
+record(compress, "$(P)STALE_CHECK:BUFFER:MIN") {
+    field(DESC, "Min recent wavelength")
+    field(ALG, "0")
+    field(INP, "$(P)STALE_CHECK:BUFFER CP MS")
+    field(NSAM, "1")
+}
+
+record(calc, "$(P)STALE"){
+    field(DESC, "Check wavelength is updating")
+    field(CALC, "a=b")
+    field(INPA, "$(P)STALE_CHECK:BUFFER:MAX CP MS")
+    field(INPB, "$(P)STALE_CHECK:BUFFER:MIN CP MS")
+    field(HIGH, "1")
+    field(HSV, "2")
+}

--- a/litronSup/litron_logic.db
+++ b/litronSup/litron_logic.db
@@ -36,4 +36,5 @@ record(bi, "$(P)STALE"){
     field(OSV, "2")
     info(INTEREST, "HIGH")
     info(archive, "VAL")
+    info(alarm, "LITRON")
 }

--- a/litronSup/litron_logic.db
+++ b/litronSup/litron_logic.db
@@ -1,4 +1,4 @@
-record(compress, "$(P)STALE_CHECK:BUFFER") {
+record(compress, "$(P)_STALE_CHECK:BUFFER") {
     field(DESC, "Buffer of previous wavelength values.")
     field(ALG, "4")
     field(INP, "$(P)WL CP MS")
@@ -6,26 +6,26 @@ record(compress, "$(P)STALE_CHECK:BUFFER") {
     field(SCAN, "1 second")
 }
 
-record(compress, "$(P)STALE_CHECK:BUFFER:MAX") {
+record(compress, "$(P)_STALE_CHECK:BUFFER:MAX") {
     field(DESC, "Max recent wavelength")
     field(ALG, "1")
-    field(INP, "$(P)STALE_CHECK:BUFFER CP MS")
+    field(INP, "$(P)_STALE_CHECK:BUFFER CP MS")
     field(NSAM, "1")
 }
 
 
-record(compress, "$(P)STALE_CHECK:BUFFER:MIN") {
+record(compress, "$(P)_STALE_CHECK:BUFFER:MIN") {
     field(DESC, "Min recent wavelength")
     field(ALG, "0")
-    field(INP, "$(P)STALE_CHECK:BUFFER CP MS")
+    field(INP, "$(P)_STALE_CHECK:BUFFER CP MS")
     field(NSAM, "1")
 }
 
 record(calc, "$(P)_STALE_CALC"){
     field(DESC, "Check wavelength is updating")
     field(CALC, "a=b")
-    field(INPA, "$(P)STALE_CHECK:BUFFER:MAX CP MS")
-    field(INPB, "$(P)STALE_CHECK:BUFFER:MIN CP MS")
+    field(INPA, "$(P)_STALE_CHECK:BUFFER:MAX CP MS")
+    field(INPB, "$(P)_STALE_CHECK:BUFFER:MIN CP MS")
 }
 
 record(bi, "$(P)STALE"){
@@ -34,4 +34,6 @@ record(bi, "$(P)STALE"){
     field(ONAM, "Stale")
     field(INP, "$(P)_STALE_CALC CP MS")
     field(OSV, "2")
+    info(INTEREST, "HIGH")
+    info(archive, "VAL")
 }

--- a/system_tests/lewis_emulators/Litron/device.py
+++ b/system_tests/lewis_emulators/Litron/device.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from typing import Callable
+from random import uniform
 
 from lewis.core.statemachine import State
 from lewis.devices import StateMachineDevice
@@ -16,6 +17,8 @@ class SimulatedLitron(StateMachineDevice):
         # Whether the hardware is "connected"
         self.connected = True
 
+        # Whether the hardware and the vi are interacting, for the purpose of stale values
+        self.hardware_connected = True
         # Whether the LVRemote software has been reinitialized
         # by sending *IDN? since the last disconnection
         # (if not, it will not reply)
@@ -30,6 +33,13 @@ class SimulatedLitron(StateMachineDevice):
 
     def nudge_down(self) -> None:
         self.crystal_pos -= self.nudge_dist
+        
+    def get_wavelength(self) -> float:
+        if self.hardware_connected:
+            return self.wavelength + uniform(-0.05, 0.05)
+        else:
+            return self.wavelength
+            
 
     def _get_state_handlers(self) -> dict[str, State]:
         return {

--- a/system_tests/lewis_emulators/Litron/interfaces/stream_interface.py
+++ b/system_tests/lewis_emulators/Litron/interfaces/stream_interface.py
@@ -81,7 +81,7 @@ class LitronStreamInterface(StreamInterface):
             case b"OPOCrystalPosition":
                 return format_lvremote_int(self._device.crystal_pos)
             case b"Wavelength":
-                return format_lvremote_float(self._device.wavelength)
+                return format_lvremote_float(self._device.get_wavelength())
             case _:
                 raise ValueError(f"Unknown LVGET parameter: {parameter}")
 

--- a/system_tests/tests/litron.py
+++ b/system_tests/tests/litron.py
@@ -98,25 +98,25 @@ class LitronTests(unittest.TestCase):
         
         
         # Make sure the buffer is empty.
-        self.ca.set_pv_value("STALE_CHECK:BUFFER.RES", 1)
-        self.ca.set_pv_value("STALE_CHECK:BUFFER:MAX.RES", 1)
-        self.ca.set_pv_value("STALE_CHECK:BUFFER:MIN.RES", 1)
+        self.ca.set_pv_value("_STALE_CHECK:BUFFER.RES", 1)
+        self.ca.set_pv_value("_STALE_CHECK:BUFFER:MAX.RES", 1)
+        self.ca.set_pv_value("_STALE_CHECK:BUFFER:MIN.RES", 1)
         
         
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer)
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 0)
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", 0)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER", empty_buffer)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER:MAX", 0)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER:MIN", 0)
         self.ca.assert_that_pv_is("STALE", "Stale")
         
         self.ca.set_pv_value("SIM:WL", 1)
         
         
         
-        self.ca.assert_that_pv_value_causes_func_to_return_true("STALE_CHECK:BUFFER", _check_empty_and_1)
+        self.ca.assert_that_pv_value_causes_func_to_return_true("_STALE_CHECK:BUFFER", _check_empty_and_1)
         self.ca.set_pv_value("SIM:WL", -1)
-        self.ca.assert_that_pv_value_causes_func_to_return_true("STALE_CHECK:BUFFER", _check_empty_and_both)
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 1)
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", -1)
+        self.ca.assert_that_pv_value_causes_func_to_return_true("_STALE_CHECK:BUFFER", _check_empty_and_both)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER:MAX", 1)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER:MIN", -1)
         self.ca.assert_that_pv_is("STALE", "Good")
         
     
@@ -126,12 +126,12 @@ class LitronTests(unittest.TestCase):
         
         # Buffer not stale when noise is enabled (default) on emulator
         self.ca.assert_that_pv_is("STALE", "Good")
-        self.ca.assert_that_pv_is_not("STALE_CHECK:BUFFER", [0.0] * STALE_TIME)
+        self.ca.assert_that_pv_is_not("_STALE_CHECK:BUFFER", [0.0] * STALE_TIME)
         
         # Buffer becomes stale after STALE_TIME has passed seconds after hardware disconnect
         self._lewis.backdoor_set_on_device("hardware_connected", False)
         self.ca.assert_that_pv_is("WL", 0)
-        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer, timeout=25)
+        self.ca.assert_that_pv_is("_STALE_CHECK:BUFFER", empty_buffer, timeout=25)
         self.ca.assert_that_pv_is("STALE", "Stale", timeout=STALE_TIME)
         self.ca.assert_that_pv_alarm_is("STALE", self.ca.Alarms.MAJOR, timeout=STALE_TIME)
 

--- a/system_tests/tests/litron.py
+++ b/system_tests/tests/litron.py
@@ -16,7 +16,7 @@ IOCS = [
         "macros": {
                     "IPADDR": "127.0.0.1", 
                    "VI_PATH": "C:/instrument/dev/ibex_vis/", 
-                   "BUFFER_SIZE":f"{STALE_TIME}"
+                   "STALE_TIME":f"{STALE_TIME}"
                    },
         "emulator": "Litron",
     },

--- a/system_tests/tests/litron.py
+++ b/system_tests/tests/litron.py
@@ -106,7 +106,7 @@ class LitronTests(unittest.TestCase):
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer)
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 0)
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", 0)
-        self.ca.assert_that_pv_is("STALE", 1)
+        self.ca.assert_that_pv_is("STALE", "Stale")
         
         self.ca.set_pv_value("SIM:WL", 1)
         
@@ -117,7 +117,7 @@ class LitronTests(unittest.TestCase):
         self.ca.assert_that_pv_value_causes_func_to_return_true("STALE_CHECK:BUFFER", _check_empty_and_both)
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 1)
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", -1)
-        self.ca.assert_that_pv_is("STALE", 0)
+        self.ca.assert_that_pv_is("STALE", "Good")
         
     
     @skip_if_recsim("requires backdoor and noise")
@@ -125,14 +125,14 @@ class LitronTests(unittest.TestCase):
         empty_buffer = [0.0] * STALE_TIME
         
         # Buffer not stale when noise is enabled (default) on emulator
-        self.ca.assert_that_pv_is("STALE", 0)
+        self.ca.assert_that_pv_is("STALE", "Good")
         self.ca.assert_that_pv_is_not("STALE_CHECK:BUFFER", [0.0] * STALE_TIME)
         
         # Buffer becomes stale after STALE_TIME has passed seconds after hardware disconnect
         self._lewis.backdoor_set_on_device("hardware_connected", False)
         self.ca.assert_that_pv_is("WL", 0)
         self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer, timeout=25)
-        self.ca.assert_that_pv_is("STALE", 1, timeout=STALE_TIME)
+        self.ca.assert_that_pv_is("STALE", "Stale", timeout=STALE_TIME)
         self.ca.assert_that_pv_alarm_is("STALE", self.ca.Alarms.MAJOR, timeout=STALE_TIME)
 
     # @skip_if_recsim("requires backdoor")

--- a/system_tests/tests/litron.py
+++ b/system_tests/tests/litron.py
@@ -1,18 +1,23 @@
 import unittest
+from typing import List
 
 from utils.channel_access import ChannelAccess
 from utils.ioc_launcher import get_default_ioc_dir
 from utils.test_modes import TestModes
-from utils.testing import get_running_lewis_and_ioc, skip_if_recsim
+from utils.testing import get_running_lewis_and_ioc, skip_if_recsim, skip_if_devsim
 
 DEVICE_PREFIX = "LITRON_01"
-
+STALE_TIME = 5
 
 IOCS = [
     {
         "name": DEVICE_PREFIX,
         "directory": get_default_ioc_dir("LITRON"),
-        "macros": {"IPADDR": "127.0.0.1", "VI_PATH": "C:/instrument/dev/ibex_vis/"},
+        "macros": {
+                    "IPADDR": "127.0.0.1", 
+                   "VI_PATH": "C:/instrument/dev/ibex_vis/", 
+                   "BUFFER_SIZE":f"{STALE_TIME}"
+                   },
         "emulator": "Litron",
     },
 ]
@@ -20,6 +25,11 @@ IOCS = [
 
 TEST_MODES = [TestModes.RECSIM, TestModes.DEVSIM]
 
+def _contains_check(array, check_vals):
+    for val in check_vals:
+        if not val in array:
+            return False
+    return True
 
 class LitronTests(unittest.TestCase):
     """
@@ -43,7 +53,7 @@ class LitronTests(unittest.TestCase):
     @skip_if_recsim("requires backdoor")
     def test_can_read_wavelength(self):
         self._lewis.backdoor_set_on_device("wavelength", 4321)
-        self.ca.assert_that_pv_is("WL", 4321)
+        self.ca.assert_that_pv_is_number("WL", 4321, 0.1)
 
     @skip_if_recsim("requires backdoor")
     def test_THAT_nudge_nudges_crystal_position(self):
@@ -74,6 +84,56 @@ class LitronTests(unittest.TestCase):
 
         # Should reinitialize automatically and begin reading properly again
         self.ca.assert_that_pv_alarm_is("WL", self.ca.Alarms.NONE, timeout=30)
+        
+    @skip_if_devsim("Requires sim record")
+    def test_THAT_buffer_corectly_handles_WL_input(self):
+        # setup test functions
+        empty_buffer = [0.0] * STALE_TIME
+        
+        def _check_empty_and_1(array):
+            return _contains_check(array, [1.0] + empty_buffer[1:])
+        
+        def _check_empty_and_both(array):
+            return _contains_check(array, [1.0, -1.0] + empty_buffer[2:])
+        
+        
+        # Make sure the buffer is empty.
+        self.ca.set_pv_value("STALE_CHECK:BUFFER.RES", 1)
+        self.ca.set_pv_value("STALE_CHECK:BUFFER:MAX.RES", 1)
+        self.ca.set_pv_value("STALE_CHECK:BUFFER:MIN.RES", 1)
+        
+        
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer)
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 0)
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", 0)
+        self.ca.assert_that_pv_is("STALE", 1)
+        
+        self.ca.set_pv_value("SIM:WL", 1)
+        
+        
+        
+        self.ca.assert_that_pv_value_causes_func_to_return_true("STALE_CHECK:BUFFER", _check_empty_and_1)
+        self.ca.set_pv_value("SIM:WL", -1)
+        self.ca.assert_that_pv_value_causes_func_to_return_true("STALE_CHECK:BUFFER", _check_empty_and_both)
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MAX", 1)
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER:MIN", -1)
+        self.ca.assert_that_pv_is("STALE", 0)
+        
+    
+    @skip_if_recsim("requires backdoor and noise")
+    def test_THAT_value_staleness_is_detected_WHEN_hardware_is_not_connected_to_vi(self):
+        empty_buffer = [0.0] * STALE_TIME
+        
+        # Buffer not stale when noise is enabled (default) on emulator
+        self.ca.assert_that_pv_is("STALE", 0)
+        self.ca.assert_that_pv_is_not("STALE_CHECK:BUFFER", [0.0] * STALE_TIME)
+        
+        # Buffer becomes stale after STALE_TIME has passed seconds after hardware disconnect
+        self._lewis.backdoor_set_on_device("hardware_connected", False)
+        self.ca.assert_that_pv_is("WL", 0)
+        self.ca.assert_that_pv_is("STALE_CHECK:BUFFER", empty_buffer, timeout=25)
+        self.ca.assert_that_pv_is("STALE", 1, timeout=STALE_TIME)
+        self.ca.assert_that_pv_alarm_is("STALE", self.ca.Alarms.MAJOR, timeout=STALE_TIME)
 
     # @skip_if_recsim("requires backdoor")
     # def test_driver_reinitializes_lvremote_on_reconnection_from_closed_tcp_connection(self):


### PR DESCRIPTION
### Description of work
Created Litron_logic db that takes a circular buffer of wavelength values and checks the max and min in order to ensure they aren't the same. this can be used to ensure minor variations in value are occuring as expected.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/8687)

### Acceptance criteria
- [ ] Tests pass
- [ ] When the emulator is set to hardware connected (seperate to connected, used to simulate the state of the vi being connected to the ioc, but the hardware not plugged into the vi), the stale pv returns good.
- [ ] when the emulator is set to hardware disconnected, after `STALE_TIME` number of seconds (default of 10) the stale pv returns stale.

### System tests
Two new tests:
 - One to test the logic of the buffers using rec sim, simply adds 1 and -1 to a buffer of zeros.
 - One to test that this behaves as expected when the device returns noisy data vs static data using the device emulator.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

